### PR TITLE
feat(api): list connected users

### DIFF
--- a/api/app/src/routes/user.ts
+++ b/api/app/src/routes/user.ts
@@ -4,7 +4,10 @@ import Router from "express-promise-router";
 import status from "http-status";
 import { createConnectedUser } from "../command/connected-user/create-connected-user";
 import { deleteConnectedUser } from "../command/connected-user/delete-connected-user";
-import { getConnectedUserOrFail } from "../command/connected-user/get-connected-user";
+import {
+  getConnectedUserOrFail,
+  getConnectedUsers,
+} from "../command/connected-user/get-connected-user";
 import { createUserToken } from "../command/cx-user/create-user-token";
 import BadRequestError from "../errors/bad-request";
 import NotFoundError from "../errors/not-found";
@@ -37,6 +40,46 @@ router.get(
     const results = await getProviderDataForType<User>(req, ConsumerHealthDataType.User);
 
     res.status(status.OK).json(results);
+  })
+);
+
+type UserIdsAndProviders = {
+  metriportUserId: string;
+  appUserId: string;
+  connectedProviders?: string[];
+};
+
+/**
+ * GET /user/users
+ *
+ * Gets all users and their connected providers for the specified customer.
+ *
+ * @return { UserIdsAndProviders[] }
+ */
+router.get(
+  "/users",
+  asyncHandler(async (req: Request, res: Response) => {
+    const cxId = getCxIdOrFail(req);
+    const results = await getConnectedUsers({ cxId });
+    const connectedUsers = await Promise.all(
+      results.map(async user => {
+        const connectedUser = await getConnectedUserOrFail({ id: user.id, cxId });
+        let connectedProviders;
+        const userInfo: UserIdsAndProviders = {
+          metriportUserId: user.id,
+          appUserId: user.cxUserId,
+        };
+        if (connectedUser.providerMap) {
+          connectedProviders = Object.keys(connectedUser.providerMap).map((key: string) => {
+            return key;
+          });
+          userInfo.connectedProviders = connectedProviders;
+        }
+        return userInfo;
+      })
+    );
+
+    res.status(status.OK).json({ connectedUsers });
   })
 );
 

--- a/docs/devices-api/api-reference/user/get-connected-providers.mdx
+++ b/docs/devices-api/api-reference/user/get-connected-providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Get Connected Providers"
-description: "Returns the specified user's connected providers"
+description: "Returns the specified user's connected providers."
 api: "GET /user/:userId/connected-providers"
 ---
 

--- a/docs/devices-api/api-reference/user/get-users-and-providers.mdx
+++ b/docs/devices-api/api-reference/user/get-users-and-providers.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Get Users and Their Providers"
+title: "Get Users and Providers"
 description: "Returns a list of users with their IDs and connected providers."
-api: "GET /user/:userId/connected-providers"
+api: "GET /user/users"
 ---
 
 ## Response

--- a/docs/devices-api/api-reference/user/get-users-and-providers.mdx
+++ b/docs/devices-api/api-reference/user/get-users-and-providers.mdx
@@ -1,0 +1,39 @@
+---
+title: "Get Users and Their Providers"
+description: "Returns a list of users with their IDs and connected providers."
+api: "GET /user/:userId/connected-providers"
+---
+
+## Response
+
+<ResponseField name="connectedUsers" type="array" required>
+  The user's connected providers
+</ResponseField>
+
+```json
+{
+  "connectedUsers": [
+    {
+      "metriportUserId": "3a3a7677-25bb-4f1b-bf3c-6e0ff46ce905",
+      "appUserId": "1234"
+    },
+    {
+      "metriportUserId": "951faef1-5cfd-464a-81f7-31f76edf309e",
+      "appUserId": "9876",
+      "connectedProviders": ["fitbit", "cronometer"]
+    }
+  ]
+}
+```
+
+<ResponseExample>
+
+```javascript Metriport SDK
+import { MetriportDevicesApi } from "@metriport/api";
+
+const metriportClient = new MetriportDevicesApi("YOUR_API_KEY");
+
+const connectedProviders = await metriportClient.getUsersAndProviders();
+```
+
+</ResponseExample>

--- a/packages/packages/api/src/devices/client/metriport.ts
+++ b/packages/packages/api/src/devices/client/metriport.ts
@@ -17,6 +17,10 @@ import { GetMetriportUserIDResponse } from "./models/get-metriport-user-id-respo
 import { SettingsResponse } from "./models/settings-response";
 import { WebhookStatusResponse } from "./models/webhook-status-response";
 import { dateIsValid } from "./util/date-util";
+import {
+  UserIdsAndProviders,
+  GetUsersAndProvidersResponse,
+} from "./models/get-users-and-providers-response";
 
 export type Options = {
   sandbox?: boolean;
@@ -56,6 +60,16 @@ export class MetriportDevicesApi {
       params: { appUserId: appUserId },
     });
     return resp.data.userId;
+  }
+
+  /**
+   * Returns all your users and their connected providers.
+   *
+   * @returns List of users with their IDs and providers.
+   */
+  async getUsersAndProviders(): Promise<{ connectedUsers: UserIdsAndProviders[] }> {
+    const resp = await this.api.get<GetUsersAndProvidersResponse>("/user/users");
+    return resp.data;
   }
 
   /**

--- a/packages/packages/api/src/devices/client/models/get-users-and-providers-response.ts
+++ b/packages/packages/api/src/devices/client/models/get-users-and-providers-response.ts
@@ -1,0 +1,9 @@
+export type UserIdsAndProviders = {
+  metriportUserId: string;
+  appUserId: string;
+  connectedProviders?: string[];
+};
+
+export interface GetUsersAndProvidersResponse {
+  connectedUsers: UserIdsAndProviders[];
+}


### PR DESCRIPTION
Ref: #_[459]_(https://github.com/metriport/metriport/issues/459)

### Dependencies

- Upstream: _[(https://github.com/metriport/metriport/pull/507)]_

### Description

- Added an endpoint to list all connected users (associated with a customer), containing their IDs and connected providers.
- Added a corresponding method in the SDK.
- Added a docs section. 
